### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ else
 endif
 	@cp -rf toolbox.json $(CURDIR)/SdOut/atmosphere/contents/$(APP_TITID)/toolbox.json
 	@touch $(CURDIR)/SdOut/atmosphere/contents/$(APP_TITID)/flags/boot2.flag
-	@echo "[tesla]\nkey_combo=L+DUP+R" > $(CURDIR)/SdOut/config/tesla/config.ini
+	@printf "[tesla]\nkey_combo=L+DUP+R" > $(CURDIR)/SdOut/config/tesla/config.ini
 	@cd $(CURDIR)/SdOut; zip -r -q -9 $(APP_TITLE).zip atmosphere config; cd $(CURDIR)
 
 #---------------------------------------------------------------------------------


### PR DESCRIPTION
Change the command `echo` to `printf` to create `config.ini` because most of the shells do not interpret escape sequences by the built in `echo` command,  `printf` is supported by almost all shells and interprets the escape sequences correctly.

The actual config.ini file generate on MSYS, MinGW and Ubuntu is:

```
[tesla]\nkey_combo=L+DUP+R
```

instead of:

```
[tesla]
key_combo=L+DUP+R
```